### PR TITLE
feat: display fancy icons on Windows Terminal

### DIFF
--- a/src/Icons/index.ts
+++ b/src/Icons/index.ts
@@ -10,7 +10,7 @@
 const { platform } = process
 
 export const icons =
-	platform === 'win32'
+	platform === 'win32' && process.env.CLI_UI_ICONS !== 'true'
 		? {
 				tick: '√',
 				cross: '×',

--- a/src/Icons/index.ts
+++ b/src/Icons/index.ts
@@ -10,7 +10,7 @@
 const { platform } = process
 
 export const icons =
-	platform === 'win32' && process.env.CLI_UI_ICONS !== 'true'
+	platform === 'win32' && !process.env.WT_SESSION
 		? {
 				tick: '√',
 				cross: '×',


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

This change allows to force the usage of the fancy icons via an environment variable, regardless of the current platform. This is because on Windows, the `conhost` shell does not support them by default (unless you change the font), but the Windows Terminal does. I couldn't find a way automatically detect whether or not the current terminal could handle these icons, so I opted for a flag.

On `conhost.exe`, some characters were not supported. Because of this, the platform is checked against `win32` to determine if the usage of these characters is allowed. 

This change updates that behavior by adding an additional check against the [`WT_SESSION`](https://github.com/microsoft/terminal/issues/840) environment variable, in order to allow these characters on the Windows Terminal, which supports them.

Sources:
- https://github.com/microsoft/terminal/issues/840

Related:
- https://github.com/sindresorhus/elegant-spinner/pull/5
- https://github.com/sindresorhus/log-symbols/pull/24
- https://github.com/sindresorhus/figures/pull/34

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/poppinss/cliui/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
