### PR TITLE
fix(task_manager): allow tasks to sometimes fail via return value

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -57,11 +57,9 @@ export type TaskCallback = (task: {
   error<T extends string | Error>(error: T): T extends string ? { message: T; isError: true } : T
 }) =>
   | Error
-  | Promise<Error>
   | { isError: true; message: string }
-  | Promise<{ isError: true; message: string }>
   | string
-  | Promise<string>
+  | Promise<Error | { isError: true; message: string } | string>
 
 /**
  * Options accepted by the tasks renderers

--- a/tests/task_manager.spec.ts
+++ b/tests/task_manager.spec.ts
@@ -339,4 +339,11 @@ test.group('TaskManager', () => {
       },
     ])
   })
+
+  test('non-deterministic async tasks (typecheck-only test)', async ({}) => {
+    const manager = new TaskManager()
+    manager.add('non-deterministic async task', async (task) => {
+      return Math.random() < 0.5 ? 'success' : task.error('failure')
+    })
+  })
 })


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
fixes #22

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

i've basically just merged the 3 possible promise return types into one promise type with a union result type.
this allows async tasks submitted via the task manager to have both success and failure return branches; before this PR async tasks could only either always fail via return value, or always return success via return value and fail by throwing an exception - using `task.error()` (where `task` is the parameter given to task callbacks) was basically impossible in actual async applications.

i've also added a typecheck-only test that verifies that submitting a non-deterministic async task is possible.
this test will never fail during `npm run test` checks, but may emit errors in `npm run typecheck` instead
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contribution guide](https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md).
- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
